### PR TITLE
replace "keyup" to "keypress" for chinese input (keycode 13)

### DIFF
--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -98,7 +98,7 @@ function submitMessage (chat_) {
 
 function addSubmitHandler (chat_) {
   const input = document.querySelector(MSG_INPUT_SELECTOR);
-  input.onkeyup = (evt) => {
+  input.onkeypress = (evt) => {
     // allow new line when shift key is pressed
     if (evt.keyCode == 13 && !evt.shiftKey) {
       evt.preventDefault();


### PR DESCRIPTION
Hey, I am Chinese user, I found that when I need to choose the candidate word, the keyup event will be trigger, so I change the event of the key code 13 (Enter) .

Below is the case of the Chinese input problem 
![](https://i.imgur.com/ZAg3nag.png)