### PR TITLE
More Maintained IG API

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "electron-log": "^2.2.6",
     "electron-updater": "^2.21.10",
     "fb": "^2.0.0",
-    "instagram-private-api": "github:ifedapoolarewaju/instagram-private-api#e8dc765f3fb1abcfd1349efc8bf2634954cb7853",
+    "instagram-private-api": "^0.6.8",
     "node-notifier": "^5.1.2",
     "nojs": "^0.1.1"
   },


### PR DESCRIPTION
Hi,
You are currently using your own fork of instagram-private-api that you haven't modified (it's just a fork). 
However the development of this module is still maintained by the community and should be used instead of your fork. 

I think using their repo would solve the issues some users had trying to connect to IG. 
Tested the app with this version, works well. 