### PR TITLE
[travis] Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+node_js:
+    - "8" # use latest LTS
+
+script:
+    - npm audit

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: node_js
 node_js:
     - "8" # use latest LTS
 
+before_install:
+    - npm install npm@latest -g
+
 script:
     - npm audit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # IG:dm Messenger
 Multi-platform Desktop application for INSTAGRAM DMs, built with electron
+![Build Status!](https://travis-ci.org/ifedapoolarewaju/igdm.svg?branch=master)
 
-### View Website 
+### View Website
 [here](http://ifedapoolarewaju.github.io/igdm/)
 
 


### PR DESCRIPTION
This add's Travis support (obviously you will need to synchronize your account with Travis before).
I think this is necessary because you ship it as an end user app, thus at least ensure security for dependencies with `npm audit`. Of course you should also add unit tests with e.g `mocha`, but that's another bottle to open up.