### PR TITLE
Publish igdm in the Snap Store for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     },
     "linux": {
       "target": [
+        "snap",
         "AppImage",
         "zip",
         "deb"


### PR DESCRIPTION
Hey @ifedapoolarewaju I work on the Snapcraft team and would love to help get igdm published in the [Snap Store](https://snapcraft.io/store), which is the app store for Linux :smiley: This pull request adds a snap to the Linux builds.

Once published, you'll have direct control of the publishing life cycle, access to metrics for weekly active devices and users will get automatic updates. I see you're using Travis, here are the docs for publishing in the Snap Store.

  * https://docs.snapcraft.io/releasing-to-the-snap-store/6848
  * https://docs.travis-ci.com/user/deployment/snaps/

I'd love to feature igdm as an editors pick in the store and put together a social campaign to promote it. Is there any other help you need to get igdm published in the snap store?