### PR TITLE
Clarified description of SEEN Receipt menu text

### DIFF
--- a/browser/js/index.js
+++ b/browser/js/index.js
@@ -100,8 +100,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelector('#seen-flagger').onclick = (e) => {
     window.shouldSendSeenFlags = !window.shouldSendSeenFlags;
     e.target.innerText = window.shouldSendSeenFlags
-      ? `DON'T SEND "SEEN" RECEIPTS`
-      : `SEND "SEEN" RECEIPTS`;
+      ? `Send "SEEN" receipts - currently Enabled`
+      : `Send "SEEN" receipts - currently Disabled`;
   }
 
   document.querySelector('#notifier-settings').onclick = (e) => {


### PR DESCRIPTION
The existing menu text for sending/not sending SEEN receipts is ambiguous.  This pull request is to help resolve that by clearly stating what the current state is.

The confusion being when the menu reads 'SEND "SEEN" RECEIPTS' a user may be unclear if that mean the current state is to send seen receipts, or they need to click the item to switch to sending seen receipts.

'Don't send "Seen" receipts' becomes 'Send "SEEN" Receipts - currently enabled'
'SEND "SEEN" RECEIPTS' becomes 'Send "SEEN" Receipts - currently disabled'

Thanks!