### PR TITLE
Render likes on messages

### DIFF
--- a/browser/css/app.css
+++ b/browser/css/app.css
@@ -178,6 +178,19 @@ button, button:focus {
   color: #666;
 }
 
+.chat .message .content .reactions-likes {
+  text-align: right;
+}
+
+.chat .message .content.ig-media .reactions-likes {
+  padding: 0 0.5rem 0.5rem;
+}
+
+.chat .message .content .reactions-likes img {
+  height: 1.4rem;
+  border-radius: 50%;
+}
+
 .message.outward .content {
   background: linear-gradient(to top right, #0371e7, #1888ff);
   color: #efefef;

--- a/browser/js/index.js
+++ b/browser/js/index.js
@@ -22,6 +22,10 @@ function unfollow (userId) {
   ipcRenderer.send('unfollow', userId);
 }
 
+function getDisplayPictureUrl (userId) {
+  ipcRenderer.send('getDisplayPictureUrl', userId);
+}
+
 // This code runs once the DOM is loaded (just in case you missed it).
 document.addEventListener('DOMContentLoaded', () => {
   ipcRenderer.on('loggedInUser', (evt, user) => {
@@ -68,6 +72,10 @@ document.addEventListener('DOMContentLoaded', () => {
     window.notifiedChatId = chatId;
     notify('Image upload failed. :( Please ensure your image is in .jpg format.', true);
   })
+
+  ipcRenderer.on('getDisplayPictureUrl', (evt, displayPicture) => {
+    renderDisplayPicture(displayPicture);
+  });
 
   document.querySelector('button.open-emoji').onclick = () => {
     const onEmojiSelected = (emoji) => {

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -27,7 +27,8 @@ function renderMessage (message, direction, time, type) {
   divContent.appendChild(dom(
     `<p class="message-time">${time ? formatTime(time) : 'Sending...'}</p>`)
   );
-  renderMessageReactions(divContent, message._params.reactions);
+
+  if (message._params) renderMessageReactions(divContent, message._params.reactions);
   div.appendChild(divContent);
   
   return div

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -27,9 +27,27 @@ function renderMessage (message, direction, time, type) {
   divContent.appendChild(dom(
     `<p class="message-time">${time ? formatTime(time) : 'Sending...'}</p>`)
   );
+  renderMessageReactions(divContent, message._params.reactions);
   div.appendChild(divContent);
   
   return div
+}
+
+function renderMessageReactions(container, reactions) {
+  if (!reactions) return;
+
+  var div = dom('<div class="reactions-likes"><img src="img/love.png"></div>')
+  reactions.likes.forEach((like) => {
+    div.appendChild(dom(`<img data-user-id="${like.sender_id}">`));
+    getDisplayPictureUrl(like.sender_id);
+  });
+  container.appendChild(div);
+}
+
+function renderDisplayPicture(displayPicture) {
+  document.querySelectorAll(`img[data-user-id="${displayPicture.userId}"]`).forEach((img) => {
+    img.src = displayPicture.url;
+  });
 }
 
 function renderMessageAsPost (container, message) {

--- a/main/instagram.js
+++ b/main/instagram.js
@@ -161,3 +161,9 @@ exports.getLoggedInUser = function (session) {
     });
   });
 }
+
+exports.getUser = function (session, userId) {
+  return new Promise((resolve, reject) => {
+    Client.Account.getById(session, userId).then(resolve).catch(reject);
+  })
+}

--- a/main/instagram.js
+++ b/main/instagram.js
@@ -165,5 +165,5 @@ exports.getLoggedInUser = function (session) {
 exports.getUser = function (session, userId) {
   return new Promise((resolve, reject) => {
     Client.Account.getById(session, userId).then(resolve).catch(reject);
-  })
+  });
 }

--- a/main/main.js
+++ b/main/main.js
@@ -248,3 +248,9 @@ electron.ipcMain.on('getUnfollowers', (_) => {
 electron.ipcMain.on('unfollow', (_, userId) => {
   instagram.unfollow(session, userId)
 })
+
+electron.ipcMain.on('getDisplayPictureUrl', (_, userId) => {
+  instagram.getUser(session, userId).then((user) => {
+    mainWindow.webContents.send('getDisplayPictureUrl', { userId: userId, url: user._params.profilePicUrl });
+  });
+});


### PR DESCRIPTION
Please review these changes.
I also have a follow-up. A message-reaction event is stored in chat history with message type `actionLog` which is currently rendered as `<unsupported message format>`. Can I make a commit to avoid rendering these messages?