### PR TITLE
Show proper titles for group chats

### DIFF
--- a/browser/js/funcs.js
+++ b/browser/js/funcs.js
@@ -32,6 +32,10 @@ function getUsernames (chat_, shouldTruncate) {
   return usernames;
 }
 
+function getChatTitle(chat_) {
+  return chat_._params.threadTitle;
+}
+
 function isCurrentChat (chat_) {
   if (window.currentChatId === DUMMY_CHAT_ID) {
     return !window.chatListHash[chat_.id];
@@ -173,7 +177,7 @@ function addNotification (el, chat_) {
       // @todo pass this as an argument instead
       window.notifiedChatId = el.getAttribute("id");
       if (isNew && window.shouldNotify && !window.isWindowFocused) {
-        notify(`new message from ${getUsernames(chat_)}`);
+        notify(`new message from ${getChatTitle(chat_)}`);
       }
     }
   }

--- a/browser/js/renderers.js
+++ b/browser/js/renderers.js
@@ -198,11 +198,11 @@ function renderContextMenu (text) {
   menu.popup({});
 }
 
-function renderChatListItem (username, msgPreview, thumbnail, id) {
+function renderChatListItem(chatTitle, msgPreview, thumbnail, id) {
   var li = document.createElement('li');
   li.classList.add('col-12', 'p-3');
   li.appendChild(dom(`<div><img class="thumb" src="${thumbnail}"></div>`));
-  li.appendChild(dom(`<div class="username ml-3 d-none d-sm-inline-block"><b>${username}</b><br>${msgPreview}</div>`));
+  li.appendChild(dom(`<div class="username ml-3 d-none d-sm-inline-block"><b>${chatTitle}</b><br>${msgPreview}</div>`));
   if (id) li.setAttribute("id", `chatlist-${id}`);
 
   return li;
@@ -231,12 +231,12 @@ function renderChatList (chatList) {
   ul.innerHTML = "";
   chatList.forEach((chat_) => {
     var msgPreview = getMsgPreview(chat_);
-    var usernames = getUsernames(chat_, true);
+    var chatTitle = getChatTitle(chat_);
     let thumbnail = '';
     if (chat_.accounts[0]) {
       thumbnail = chat_.accounts[0]._params.picture;
     }
-    var li = renderChatListItem(usernames, msgPreview, thumbnail, chat_.id);
+    var li = renderChatListItem(chatTitle, msgPreview, thumbnail, chat_.id);
 
     registerChatUser(chat_);
     if (isActive(chat_)) setActive(li);
@@ -259,12 +259,15 @@ function renderChatList (chatList) {
 }
 
 function renderChatHeader (chat_) {
-  let usernames = getUsernames(chat_);
-  let b = dom(`<b>${usernames}</b>`);
+  let chatTitle = getChatTitle(chat_);
+  let b = dom(`<b>${chatTitle}</b>`);
 
   if (chat_.accounts.length === 1) {
     // open user profile in browser
-    b.onclick = () => openInBrowser(`https://instagram.com/${usernames}`)
+    b.onclick = () =>
+      openInBrowser(
+        `https://instagram.com/${getUsernames(chat_)}`
+      );
   }
   let chatTitleContainer = document.querySelector('.chat-title');
   chatTitleContainer.innerHTML = '';


### PR DESCRIPTION
Currently, IGDM uses a comma-separated list of the usernames in a group chat as its title instead of the group chat's actual name. This pull request fixes that.