### PR TITLE
Disabled Drag and Drop

### DIFF
--- a/browser/js/index.js
+++ b/browser/js/index.js
@@ -26,6 +26,17 @@ function getDisplayPictureUrl (userId) {
   ipcRenderer.send('getDisplayPictureUrl', userId);
 }
 
+//Disable Drag and Drop on Electrum
+document.addEventListener('dragover',function(event){
+  event.preventDefault();
+  return false;
+},false);
+
+document.addEventListener('drop',function(event){
+  event.preventDefault();
+  return false;
+},false);
+
 // This code runs once the DOM is loaded (just in case you missed it).
 document.addEventListener('DOMContentLoaded', () => {
   ipcRenderer.on('loggedInUser', (evt, user) => {


### PR DESCRIPTION
Due to using Chromium, the client could drag and drop an image, video or audio and IGDM would exit the window and starting play it, with no way of getting back to main screen.
Thus, I disabled the option to drag and drop.
However, I think a nicer implementation would be using drag and drop to send images or videos, but I don't have enough programming skills to code that.